### PR TITLE
Nested list patch

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function filterMarkdown(text: string, overrideAmpersandEscape = false): s
   const noUrls = noFrontmatter.replace(/https?:\/\/[^\s]+/g, '');
 
   // Remove code blocks (e.g., fenced with ``` or indented by 4 spaces)
-  const noCodeBlocks = noUrls.replace(/```[\s\S]*?```/g, '').replace(/^( {4}|\t).+/gm, '');
+  const noCodeBlocks = noUrls.replace(/```[\s\S]*?```/g, '').replace(/^( {4}|\t)(?!(?:[-*+ ]|\d+\.) ).+/gm, '');
 
   // Remove inline markdown syntax
   let cleanedMarkdown = noCodeBlocks

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function filterMarkdown(text: string, overrideAmpersandEscape = false): s
   // Remove URLs
   const noUrls = noFrontmatter.replace(/https?:\/\/[^\s]+/g, '');
 
-  // Remove code blocks (e.g., fenced with ``` or indented by 4 spaces)
+  // Remove code blocks (e.g., fenced with ``` or indented by 4 spaces, unless they are nested list item)
   const noCodeBlocks = noUrls.replace(/```[\s\S]*?```/g, '').replace(/^( {4}|\t)(?!(?:[-*+ ]|\d+\.) ).+/gm, '');
 
   // Remove inline markdown syntax


### PR DESCRIPTION
Currently code block filtering in filterMarkdown also filters nested lists such that given the following text:

- Some information
    - additional details

Only "Some information" is spoken. This regex change prevents indented line starts with -, *, or a number from being filtered.