### PR TITLE
Add new command: read from cursor; minor regex fix for callout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -207,6 +207,17 @@ export default class EdgeTTSPlugin extends Plugin {
 		});
 
 		this.addCommand({
+			id: 'read-from-cursor',
+			name: 'Read from cursor aloud',
+			editorCallback: (editor, view) => {
+				const lastLine = editor.lastLine();
+				const lastCh = editor.getLine(lastLine).length;
+				const textFromCursor = editor.getRange(editor.getCursor(), { line: lastLine, ch: lastCh });
+				this.audioManager.startPlayback(textFromCursor);
+			}
+		});
+
+		this.addCommand({
 			id: 'show-floating-playback-controls',
 			name: 'Show floating playback controls',
 			callback: () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,13 +219,13 @@ export function filterMarkdown(text: string, textFiltering?: EdgeTTSPluginSettin
   // Filter callouts if enabled
   if (textFiltering?.filterCallouts) {
     // Remove Obsidian callout syntax but keep the content
-    // Match lines starting with > [!type] and remove the callout formatting
-    processedText = processedText.replace(/^>\s*\[![^\]]*\]\s*/gm, '');
+    // Match lines starting with > [!type] or > >[!nested] and remove the callout formatting
+    processedText = processedText.replace(/^>[>\s]*\[![^\]]*\]\s*/gm, '');
     // Also remove subsequent > markers that are part of the callout
     const lines = processedText.split('\n');
     let inCallout = false;
     const filteredLines = lines.map(line => {
-      if (line.match(/^>\s*\[![^\]]*\]/)) {
+      if (line.match(/^>\s*\[![^\]]*\]/)) {  // ? this condition will never be true because all callout syntax has already been removed above
         inCallout = true;
         return line.replace(/^>\s*\[![^\]]*\]\s*/, '');
       } else if (inCallout && line.startsWith('> ')) {
@@ -292,15 +292,16 @@ export function filterMarkdown(text: string, textFiltering?: EdgeTTSPluginSettin
   // Remove strikethrough (~~text~~) but keep the content
   cleanedMarkdown = cleanedMarkdown.replace(/~~(.*?)~~/g, '$1');
 
-  // Remove other markdown characters (e.g., #, -, *, etc., not part of inline code)
   cleanedMarkdown = cleanedMarkdown
+    // Remove blockquote markers (e.g., "> ", "> >") only at the start of a line
+    // Blockquote markers are replaced first, because we can have headers or list inside blockquote / callout
+    .replace(/^>[>\s]*/gm, '')
+    // Remove other markdown characters (e.g., #, -, *, etc., not part of inline code)
     .replace(/^[#*-]+\s*/gm, '')
     // Remove unordered list markers (e.g., "- ", "* ", "+ ")
     .replace(/^[\-\+\*]\s+/gm, '')
     // Remove ordered list numbers (e.g., "1. ", "2. ")
     .replace(/^\d+\.\s+/gm, '')
-    // Remove blockquote markers (e.g., "> ") only at the start of a line
-    .replace(/^>\s+/gm, '')
     // Remove horizontal rules (e.g., "---", "***")
     .replace(/^[-*]{3,}\s*$/gm, '');
 


### PR DESCRIPTION
1. Add a command to read text from the cursor position to the end
2. Fix regex to correctly remove syntax for nested callout (`> >[!type]`) and headers inside blockquotes (`> ## header`)